### PR TITLE
hacs and hassfest actions to validate commits

### DIFF
--- a/.github/workflows/hacsaction.yaml
+++ b/.github/workflows/hacsaction.yaml
@@ -1,0 +1,16 @@
+name: HACS Action
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  hacs:
+    name: HACS Action
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - name: HACS Action
+        uses: "hacs/action@main"
+        with:
+          category: "integration"

--- a/.github/workflows/hacsaction.yaml
+++ b/.github/workflows/hacsaction.yaml
@@ -14,3 +14,4 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
+          ignore: "topics"

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,12 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: home-assistant/actions/hassfest@master

--- a/custom_components/alarmdotcom/manifest.json
+++ b/custom_components/alarmdotcom/manifest.json
@@ -2,7 +2,7 @@
   "domain": "alarmdotcom",
   "name": "Alarm.com",
   "documentation": "https://www.github.com/uvjustin/alarmdotcom",
-  "issue_tracker": "https://github.com/uvjustin/alarmdotcom/issues",
+  "issue_tracker": "https://www.github.com/uvjustin/alarmdotcom/issues",
   "requirements": [
     "beautifulsoup4==4.9.3",
     "pyalarmdotcomajax==0.1.11"

--- a/custom_components/alarmdotcom/manifest.json
+++ b/custom_components/alarmdotcom/manifest.json
@@ -2,6 +2,7 @@
   "domain": "alarmdotcom",
   "name": "Alarm.com",
   "documentation": "https://www.github.com/uvjustin/alarmdotcom",
+  "issue_tracker": "https://github.com/uvjustin/alarmdotcom/issues",
   "requirements": [
     "beautifulsoup4==4.9.3",
     "pyalarmdotcomajax==0.1.11"

--- a/custom_components/alarmdotcom/manifest.json
+++ b/custom_components/alarmdotcom/manifest.json
@@ -9,5 +9,6 @@
   ],
   "dependencies": [],
   "version": "0.1.10",
-  "codeowners": ["@uvjustin"]
+  "codeowners": ["@uvjustin"],
+  "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
Added HACS and hassfest action.

- HACSaction.yaml will check against the HACS codebase to ensure that the integration is compliant with the format needs for HACS, and alert you when committing changes that may cause validation issues with HACS repository management. In short, this will primarily let you know of breaking changes from HACS that you need to address in your HACS file.

- hassfest.yaml will run against the Home Assistant itself, to ensure that the integration is complaint with HA's latest standards and requirements for integrations and their data, advising you of anything that may cause it to throw and error or warning due to compatibility or depricated reasons. It will also glance at the Beta branches of HA coming down the wipe, to give you a soft warning about future changes coming that may cause issues as well so you can stay ahead of them.

Both are currently configured to run at commit and PR merge, but can optionally also be modified to run on a cronjob as well, if desired, to catch changes upstream on HACS and HA over periods of time when code may not be changed and changes missed.