### PR TITLE
Enhance lock support to add multiple locks

### DIFF
--- a/custom_components/alarmdotcom/manifest.json
+++ b/custom_components/alarmdotcom/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "alarmdotcom",
-  "name": "Alarm.com",
-  "documentation": "https://www.github.com/uvjustin/alarmdotcom",
-  "issue_tracker": "https://www.github.com/uvjustin/alarmdotcom/issues",
+  "name": "Alarm.com kevin-david",
+  "documentation": "https://www.github.com/kevin-david/alarmdotcom",
+  "issue_tracker": "https://www.github.com/kevin-david/alarmdotcom/issues",
   "requirements": [
     "beautifulsoup4==4.10.0",
-    "pyalarmdotcomajax==0.1.13"
+    "git+https://github.com/kevin-david/pyalarmdotcomajax.git@multi_lock#pyalarmdotcomajax==0.2.0"
   ],
   "dependencies": [],
-  "version": "0.1.12",
-  "codeowners": ["@uvjustin"],
+  "version": "0.2.0",
+  "codeowners": ["@kevin-david"],
   "iot_class": "cloud_polling"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Alarmdotcom",
+  "name": "Alarmdotcom-kevin-david",
   "render_readme": true,
   "homeassistant": "0.105.0"
 }


### PR DESCRIPTION
Requires the changes in https://github.com/uvjustin/pyalarmdotcomajax/pull/17 - uses multi-lock support added there to give HASS multiple entities from `lock.py`. While at it, I also added automatic naming from the entities in Alarm.com

Also reacts to the other breaking changes in that PR.

In the future, it would be interesting to investigate using a coordinator as described in https://developers.home-assistant.io/docs/integration_fetching_data/#coordinated-single-api-poll-for-data-for-all-entities to both reduce API calls and simplify setup (only one config entry vs duplicated ones for locks/alarms) but that seemed like a huge change once I started trying to go down that road, and I wanted to get something working :) Here's what that might look like from another integration I use: https://github.com/itchannel/fordpass-ha/blob/master/custom_components/fordpass/sensor.py