### PR TITLE
Fixes crashes when encountering unpermissioned device types.

### DIFF
--- a/custom_components/alarmdotcom/manifest.json
+++ b/custom_components/alarmdotcom/manifest.json
@@ -3,9 +3,9 @@
   "name": "Alarm.com",
   "documentation": "https://www.github.com/uvjustin/alarmdotcom",
   "issue_tracker": "https://www.github.com/uvjustin/alarmdotcom/issues",
-  "requirements": ["beautifulsoup4==4.10.0", "pyalarmdotcomajax==0.2.0b0"],
+  "requirements": ["beautifulsoup4==4.10.0", "pyalarmdotcomajax==0.2.0b2"],
   "dependencies": [],
-  "version": "0.2.0-beta",
+  "version": "0.2.0-beta.3",
   "codeowners": ["@uvjustin", "@elahd"],
   "iot_class": "cloud_polling",
   "config_flow": true


### PR DESCRIPTION
It looks like Alarm.com returns HTTP status code 423 for queries on device types that are unsupported by the provider / account. This enhancement skips those device types instead of crashing.