### PR TITLE
Use arm_code also for lock code

### DIFF
--- a/custom_components/alarmdotcom/lock.py
+++ b/custom_components/alarmdotcom/lock.py
@@ -72,7 +72,7 @@ class ADCILock(ADCIEntity, LockEntity):  # type: ignore
         super().__init__(controller, device_data)
 
         self._arm_code: str | None = self._controller.config_entry.options.get(
-            "lock_code"
+            "arm_code"
         )
 
         self._device: adci.ADCILockData = device_data


### PR DESCRIPTION
The code that was supposed to be valid for both alarm and locks was not valid for locks.