### PR TITLE
Fix timeout issue on core restart

### DIFF
--- a/custom_components/alarmdotcom/controller.py
+++ b/custom_components/alarmdotcom/controller.py
@@ -103,7 +103,7 @@ class ADCIController:
                 twofactorcookie=twofactorcookie,
             )
 
-            async with async_timeout.timeout(15):
+            async with async_timeout.timeout(30):
                 login_result = await self._alarm.async_login()
 
                 return login_result


### PR DESCRIPTION
Fixes #95 
Fixes #97 
Fixes #98 

Looking at the debug logs, the time between `DEBUG (MainThread) [pyalarmdotcomajax] Attempting to log in to Alarm.com` and `DEBUG (MainThread) [pyalarmdotcomajax] Response status from Alarm.com: 200` can end up being >15s, which causes the timeout condition to trip before proceeding with `_async_get_identity_info()`. By increasing this timeout value (I just doubled it), it seems to run normally on a core restart.