### PR TITLE
Update for Alarm Panel states

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -76,7 +76,7 @@
         "github-cli": "latest"
     },
     "forwardPorts": [8123],
-    "image": "mcr.microsoft.com/devcontainers/python:3.11",
+    "image": "mcr.microsoft.com/devcontainers/python:3.13",
     "name": "alarmdotcom",
     "postCreateCommand": ["scripts/setup.sh"],
     "remoteUser": "vscode"

--- a/custom_components/alarmdotcom/alarm_control_panel.py
+++ b/custom_components/alarmdotcom/alarm_control_panel.py
@@ -9,19 +9,13 @@ from typing import Any
 
 from homeassistant import core
 from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelState,
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
     CodeFormat,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_ARMING,
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_DISARMING,
-)
+
 from homeassistant.helpers.entity_platform import AddEntitiesCallback, DiscoveryInfoType
 from pyalarmdotcomajax.devices.partition import Partition as libPartition
 from pyalarmdotcomajax.exceptions import NotAuthorized
@@ -113,23 +107,23 @@ class AlarmControlPanel(HardwareBaseDevice, AlarmControlPanelEntity):  # type: i
         if self._device.state == self._device.desired_state:
             match self._device.state:
                 case libPartition.DeviceState.DISARMED:
-                    return str(STATE_ALARM_DISARMED)
+                    return str(AlarmControlPanelState.DISARMED)
                 case libPartition.DeviceState.ARMED_STAY:
-                    return str(STATE_ALARM_ARMED_HOME)
+                    return str(AlarmControlPanelState.ARMED_HOME)
                 case libPartition.DeviceState.ARMED_AWAY:
-                    return str(STATE_ALARM_ARMED_AWAY)
+                    return str(AlarmControlPanelState.ARMED_AWAY)
                 case libPartition.DeviceState.ARMED_NIGHT:
-                    return str(STATE_ALARM_ARMED_NIGHT)
+                    return str(AlarmControlPanelState.ARMED_NIGHT)
         else:
             match self._device.desired_state:
                 case libPartition.DeviceState.DISARMED:
-                    return str(STATE_ALARM_DISARMING)
+                    return str(AlarmControlPanelState.DISARMING)
                 case (
                     libPartition.DeviceState.ARMED_STAY
                     | libPartition.DeviceState.ARMED_AWAY
                     | libPartition.DeviceState.ARMED_NIGHT
                 ):
-                    return str(STATE_ALARM_ARMING)
+                    return str(AlarmControlPanelState.ARMING)
 
         LOGGER.error(
             f"Cannot determine state. Found raw state of {self._device.state} and desired state of"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 colorlog==6.8.2
-homeassistant==2024.3.3
+homeassistant==2025.11.1
 pip>=23.3.1
 pre-commit>=3.3.3


### PR DESCRIPTION
Fix for #500 to make the current stable version be compatable with last HA update. 

- updated python to 3.13 (for ha update)
- updated homeassistant to 2025.11.1
- replaced deleted constants with AlarmControlPanelState constants